### PR TITLE
Column References + Projection Push Down

### DIFF
--- a/src/Cli/Program.cs
+++ b/src/Cli/Program.cs
@@ -197,7 +197,7 @@ void EvalQuery(string query, QueryPlanner queryPlanner)
 
     var plan = queryPlanner.CreatePlan(statement);
 
-    var it = new Interpreter();
+    var it = new Interpreter(bufferPool);
     var result = it.Execute(plan).ToList();
     stopwatch.Stop();
 
@@ -207,7 +207,7 @@ void EvalQuery(string query, QueryPlanner queryPlanner)
     Console.WriteLine($"{numRows} rows in {stopwatch.ElapsedMilliseconds:N}ms");
 }
 
-void PrintTable(List<RowGroup> result)
+void PrintTable(List<MaterializedRowGroup> result)
 {
     var rg = result[0];
     var columnHeader = string.Join(", ", rg.Columns.Select(c => c.Name));

--- a/src/Database.Core/BufferPool/MemoryBasedTable.cs
+++ b/src/Database.Core/BufferPool/MemoryBasedTable.cs
@@ -1,10 +1,46 @@
+using Database.Core.Catalog;
 using Database.Core.Execution;
 
 namespace Database.Core.BufferPool;
 
-public class MemoryBasedTable(int NumColumns)
+public class MemoryBasedTable(MemoryStorage storage)
 {
     private Dictionary<int, IColumn[]> _rowGroups { get; set; } = new();
+    private List<ColumnSchema> _schema = new();
+
+    public int NumColumns => _schema.Count;
+    public IReadOnlyList<ColumnSchema> Schema => _schema;
+
+    private int _nextRowGroup = 0;
+
+    public RowGroupRef AddRowGroup()
+    {
+        return new RowGroupRef(--_nextRowGroup);
+    }
+
+    public ColumnRef AddColumnToSchema(string name, DataType type)
+    {
+        var columnId = NumColumns;
+        var columnRef = new ColumnRef(storage, -1, columnId);
+        var newColumn = new ColumnSchema(
+            columnRef,
+            (ColumnId)columnId,
+            name,
+            type,
+            type.ClrTypeFromDataType(),
+            -1); // TODO remove all these extra indexes
+        _schema.Add(newColumn);
+        return columnRef;
+    }
+
+    public ColumnSchema GetColumnSchema(ColumnRef columnRef)
+    {
+        if (!columnRef.Storage.Equals(storage))
+        {
+            throw new Exception($"Column ref {columnRef} does not belong to table {storage.TableId}");
+        }
+        return _schema[columnRef.Column];
+    }
 
     public IColumn GetColumn(ColumnRef columnRef)
     {

--- a/src/Database.Core/BufferPool/MemoryBasedTable.cs
+++ b/src/Database.Core/BufferPool/MemoryBasedTable.cs
@@ -23,6 +23,12 @@ public class MemoryBasedTable(MemoryStorage storage)
 
     public ColumnSchema AddColumnToSchema(string name, DataType type)
     {
+        if (name == "")
+        {
+            // TODO this currently breaks because I'm not generating unique column names
+            // throw new Exception("Column name cannot be empty");
+        }
+
         var columnId = NumColumns;
         var columnRef = new ColumnRef(storage, -1, columnId);
         var newColumn = new ColumnSchema(

--- a/src/Database.Core/BufferPool/MemoryBasedTable.cs
+++ b/src/Database.Core/BufferPool/MemoryBasedTable.cs
@@ -13,11 +13,12 @@ public class MemoryBasedTable(MemoryStorage storage)
     public int NumColumns => _schema.Count;
     public IReadOnlyList<ColumnSchema> Schema => _schema;
 
-    private int _nextRowGroup = 0;
+    private static volatile int _nextRowGroup = 0;
 
     public RowGroupRef AddRowGroup()
     {
-        return new RowGroupRef(--_nextRowGroup);
+        var id = Interlocked.Decrement(ref _nextRowGroup);
+        return new RowGroupRef(id);
     }
 
     public ColumnSchema AddColumnToSchema(string name, DataType type)

--- a/src/Database.Core/BufferPool/MemoryBasedTable.cs
+++ b/src/Database.Core/BufferPool/MemoryBasedTable.cs
@@ -36,8 +36,7 @@ public class MemoryBasedTable(MemoryStorage storage)
             (ColumnId)columnId,
             name,
             type,
-            type.ClrTypeFromDataType(),
-            -1); // TODO remove all these extra indexes
+            type.ClrTypeFromDataType());
         _schema.Add(newColumn);
         return newColumn;
     }

--- a/src/Database.Core/BufferPool/MemoryBasedTable.cs
+++ b/src/Database.Core/BufferPool/MemoryBasedTable.cs
@@ -18,7 +18,7 @@ public class MemoryBasedTable(MemoryStorage storage)
         return new RowGroupRef(--_nextRowGroup);
     }
 
-    public ColumnRef AddColumnToSchema(string name, DataType type)
+    public ColumnSchema AddColumnToSchema(string name, DataType type)
     {
         var columnId = NumColumns;
         var columnRef = new ColumnRef(storage, -1, columnId);
@@ -30,7 +30,7 @@ public class MemoryBasedTable(MemoryStorage storage)
             type.ClrTypeFromDataType(),
             -1); // TODO remove all these extra indexes
         _schema.Add(newColumn);
-        return columnRef;
+        return newColumn;
     }
 
     public ColumnSchema GetColumnSchema(ColumnRef columnRef)

--- a/src/Database.Core/BufferPool/MemoryBasedTable.cs
+++ b/src/Database.Core/BufferPool/MemoryBasedTable.cs
@@ -1,0 +1,27 @@
+using Database.Core.Execution;
+
+namespace Database.Core.BufferPool;
+
+public class MemoryBasedTable(int NumColumns)
+{
+    private Dictionary<int, IColumn[]> _rowGroups { get; set; } = new();
+
+    public IColumn GetColumn(ColumnRef columnRef)
+    {
+        if (!_rowGroups.TryGetValue(columnRef.RowGroup, out var rowGroup))
+        {
+            throw new Exception($"Row group {columnRef} not found");
+        }
+        return rowGroup[columnRef.Column];
+    }
+
+    public void PutColumn(ColumnRef columnRef, IColumn column)
+    {
+        if (!_rowGroups.TryGetValue(columnRef.RowGroup, out var rowGroup))
+        {
+            rowGroup = new IColumn[NumColumns];
+            _rowGroups[columnRef.RowGroup] = rowGroup;
+        }
+        rowGroup[columnRef.Column] = column;
+    }
+}

--- a/src/Database.Core/BufferPool/ParquetPool.cs
+++ b/src/Database.Core/BufferPool/ParquetPool.cs
@@ -1,5 +1,7 @@
 using System.Collections.Concurrent;
 using System.IO.MemoryMappedFiles;
+using Database.Core.Catalog;
+using Database.Core.Execution;
 using Parquet;
 using Parquet.Schema;
 
@@ -21,6 +23,11 @@ public class ParquetPool
 {
     private ReaderWriterLockSlim _lock = new(LockRecursionPolicy.NoRecursion);
     private Dictionary<string, RefCounter<ParquetFileHandle>> _openFiles = new();
+
+    private Dictionary<ColumnRef, IColumn> _columnCache = new();
+
+    private int _nextMemoryTableId = 0;
+    private Dictionary<TableId, MemoryBasedTable> _memoryTables = new();
 
     public ParquetFileHandle OpenFile(string path)
     {
@@ -58,6 +65,52 @@ public class ParquetPool
         {
             _lock.ExitWriteLock();
         }
+    }
+
+    public MemoryStorage OpenMemoryTable(int numColumns)
+    {
+        var id = (TableId)(--_nextMemoryTableId);
+        _memoryTables.Add(id, new MemoryBasedTable(numColumns));
+        return new MemoryStorage(id);
+    }
+
+    public MemoryBasedTable GetMemoryTable(TableId id)
+    {
+        return _memoryTables[id];
+    }
+
+    public IColumn GetColumn(ColumnRef columnRef)
+    {
+        if (_columnCache.TryGetValue(columnRef, out var column))
+        {
+            return column;
+        }
+
+        if (columnRef.Storage is MemoryStorage storage)
+        {
+            var table = _memoryTables[storage.TableId];
+            return table.GetColumn(columnRef);
+        }
+
+        if (columnRef.Storage is not ParquetStorage parquet)
+        {
+            throw new Exception($"unexpected storage type {columnRef.Storage.GetType().Name} for column ref");
+        }
+
+        var handle = parquet.Handle;
+        var reader = handle.Reader.OpenRowGroupReader(columnRef.RowGroup);
+        var field = handle.DataFields[columnRef.Column];
+        var parquetCol = reader.ReadColumnAsync(field).GetAwaiter().GetResult();
+        var (targetType, finalCopy) = TypeConversion.RemoveNullablesHack(parquetCol, field);
+        var columnObj = ColumnHelper.CreateColumn(targetType, field.Name, columnRef.Column, finalCopy);
+        _columnCache.Add(columnRef, columnObj);
+        return columnObj;
+    }
+
+    public T GetValue<T>(RowRef rowRef)
+    {
+        var column = GetColumn(rowRef.ColumnRef);
+        return (T)column[rowRef.Row]!;
     }
 
     private RefCounter<ParquetFileHandle> OpenReader(string path)

--- a/src/Database.Core/BufferPool/ParquetPool.cs
+++ b/src/Database.Core/BufferPool/ParquetPool.cs
@@ -67,6 +67,7 @@ public class ParquetPool
         }
     }
 
+    // TODO add some descritive info in here for debugging, like a name, how it was created
     public MemoryStorage OpenMemoryTable()
     {
         var id = (TableId)(--_nextMemoryTableId);
@@ -106,7 +107,7 @@ public class ParquetPool
         var field = handle.DataFields[columnRef.Column];
         var parquetCol = reader.ReadColumnAsync(field).GetAwaiter().GetResult();
         var (targetType, finalCopy) = TypeConversion.RemoveNullablesHack(parquetCol, field);
-        var columnObj = ColumnHelper.CreateColumn(targetType, field.Name, columnRef.Column, finalCopy);
+        var columnObj = ColumnHelper.CreateColumn(targetType, field.Name, finalCopy);
         _columnCache.Add(columnRef, columnObj);
         return columnObj;
     }

--- a/src/Database.Core/BufferPool/ParquetPool.cs
+++ b/src/Database.Core/BufferPool/ParquetPool.cs
@@ -129,12 +129,6 @@ public class ParquetPool
         }, column);
     }
 
-    // public T GetValue<T>(RowRef rowRef)
-    // {
-    //     var column = GetColumn(rowRef.ColumnRef);
-    //     return (T)column[rowRef.Row]!;
-    // }
-
     private RefCounter<ParquetFileHandle> OpenReader(string path)
     {
         var file = MemoryMappedFile.CreateFromFile(path);

--- a/src/Database.Core/Catalog/Catalog.cs
+++ b/src/Database.Core/Catalog/Catalog.cs
@@ -31,8 +31,7 @@ public record Catalog(ParquetPool BufferPool)
                 columnId,
                 field.Name,
                 field.ClrType.DataTypeFromClrType(),
-                field.ClrType,
-                i
+                field.ClrType
                 ));
         }
 

--- a/src/Database.Core/Catalog/TableSchema.cs
+++ b/src/Database.Core/Catalog/TableSchema.cs
@@ -38,13 +38,11 @@ public enum ColumnId : int { }
 
 /// <summary>
 /// Represents the schema for a column within a database table.
-/// <param name="Index">The offset in the parquet file</param>
 /// </summary>
 public record ColumnSchema(
     ColumnRef ColumnRef,
     ColumnId Id,
     string Name,
     DataType DataType,
-    Type ClrType,
-    int Index
+    Type ClrType
     );

--- a/src/Database.Core/Catalog/TableSchema.cs
+++ b/src/Database.Core/Catalog/TableSchema.cs
@@ -1,8 +1,11 @@
+using Database.Core.Execution;
+
 namespace Database.Core.Catalog;
 
 public enum TableId : int { }
 
 public record TableSchema(
+    IStorageLocation Storage,
     TableId Id,
     string Name,
     List<ColumnSchema> Columns,
@@ -38,6 +41,7 @@ public enum ColumnId : int { }
 /// <param name="Index">The offset in the parquet file</param>
 /// </summary>
 public record ColumnSchema(
+    ColumnRef ColumnRef,
     ColumnId Id,
     string Name,
     DataType DataType,

--- a/src/Database.Core/Catalog/TableSchema.cs
+++ b/src/Database.Core/Catalog/TableSchema.cs
@@ -8,7 +8,7 @@ public record TableSchema(
     IStorageLocation Storage,
     TableId Id,
     string Name,
-    List<ColumnSchema> Columns,
+    IReadOnlyList<ColumnSchema> Columns,
     string Location,
     long NumRows,
     int NumRowGroups,

--- a/src/Database.Core/Execution/Column.cs
+++ b/src/Database.Core/Execution/Column.cs
@@ -10,20 +10,9 @@ public interface IColumn
 
     int Length { get; }
 
-    object? this[long index] { get; }
+    object? this[int index] { get; }
 
     Array ValuesArray { get; }
-
-    public static IColumn CreateColumn(Type dataType, string name, int length)
-    {
-        var values = Array.CreateInstance(dataType, length);
-
-        return ColumnHelper.CreateColumn(
-            dataType,
-            name,
-            values
-        );
-    }
 
     public void SetValues(Array source, bool[] mask);
 }
@@ -34,7 +23,7 @@ public record Column<T>(string Name, T[] Values) : IColumn
 
     public int Length => Values.Length;
 
-    public object? this[long index] => Values[index];
+    public object? this[int index] => Values[index];
     public Array ValuesArray => Values;
 
     public void SetValues(Array source, bool[] mask)

--- a/src/Database.Core/Execution/Column.cs
+++ b/src/Database.Core/Execution/Column.cs
@@ -6,7 +6,6 @@ namespace Database.Core.Execution;
 public interface IColumn
 {
     string Name { get; }
-    int Index { get; }
     Type Type { get; }
 
     int Length { get; }
@@ -15,14 +14,13 @@ public interface IColumn
 
     Array ValuesArray { get; }
 
-    public static IColumn CreateColumn(Type dataType, string name, int index, int length)
+    public static IColumn CreateColumn(Type dataType, string name, int length)
     {
         var values = Array.CreateInstance(dataType, length);
 
         return ColumnHelper.CreateColumn(
             dataType,
             name,
-            index,
             values
         );
     }
@@ -30,7 +28,7 @@ public interface IColumn
     public void SetValues(Array source, bool[] mask);
 }
 
-public record Column<T>(string Name, int Index, T[] Values) : IColumn
+public record Column<T>(string Name, T[] Values) : IColumn
 {
     public Type Type => typeof(T);
 
@@ -59,7 +57,7 @@ public static class ColumnHelper
     // TODO make thread safe
     private static readonly Dictionary<Type, ConstructorInfo> _typeCache = new();
 
-    public static IColumn CreateColumn(Type targetType, string name, int index, Array values)
+    public static IColumn CreateColumn(Type targetType, string name, Array values)
     {
         if (!_typeCache.TryGetValue(targetType, out var ctor))
         {
@@ -70,7 +68,6 @@ public static class ColumnHelper
 
         return (IColumn)ctor.Invoke([
             name,
-            index,
             values
         ]);
     }

--- a/src/Database.Core/Execution/Column.cs
+++ b/src/Database.Core/Execution/Column.cs
@@ -11,7 +11,7 @@ public interface IColumn
 
     int Length { get; }
 
-    object? this[int index] { get; }
+    object? this[long index] { get; }
 
     Array ValuesArray { get; }
 
@@ -36,7 +36,7 @@ public record Column<T>(string Name, int Index, T[] Values) : IColumn
 
     public int Length => Values.Length;
 
-    public object? this[int index] => Values[index];
+    public object? this[long index] => Values[index];
     public Array ValuesArray => Values;
 
     public void SetValues(Array source, bool[] mask)

--- a/src/Database.Core/Execution/ColumnRef.cs
+++ b/src/Database.Core/Execution/ColumnRef.cs
@@ -1,0 +1,13 @@
+using Database.Core.BufferPool;
+using Database.Core.Catalog;
+
+namespace Database.Core.Execution;
+
+public interface IStorageLocation { }
+
+public record struct MemoryStorage(TableId TableId) : IStorageLocation { }
+public record struct ParquetStorage(ParquetFileHandle Handle) : IStorageLocation { }
+
+public record struct ColumnRef(IStorageLocation Storage, int RowGroup, int Column);
+
+public record struct RowRef(ColumnRef ColumnRef, long Row);

--- a/src/Database.Core/Execution/ColumnRef.cs
+++ b/src/Database.Core/Execution/ColumnRef.cs
@@ -10,4 +10,4 @@ public record struct ParquetStorage(ParquetFileHandle Handle) : IStorageLocation
 
 public record struct ColumnRef(IStorageLocation Storage, int RowGroup, int Column);
 
-public record struct RowRef(ColumnRef ColumnRef, long Row);
+public record struct RowGroupRef(int RowGroup);

--- a/src/Database.Core/Execution/Interpreter.cs
+++ b/src/Database.Core/Execution/Interpreter.cs
@@ -1,17 +1,36 @@
+using Database.Core.BufferPool;
 using Database.Core.Planner;
 
 namespace Database.Core.Execution;
 
-public class Interpreter
+public class Interpreter(ParquetPool BufferPool)
 {
-    public IEnumerable<RowGroup> Execute(QueryPlan plan)
+    public IEnumerable<MaterializedRowGroup> Execute(QueryPlan plan)
     {
         var operation = plan.Operation;
         var group = operation.Next();
         while (group != null)
         {
-            yield return group;
+            yield return Materialize(group);
             group = operation.Next();
         }
+    }
+
+    private MaterializedRowGroup Materialize(RowGroup group)
+    {
+        var columns = new List<IColumn>(group.NumColumns);
+
+        for (var i = 0; i < group.NumColumns; i++)
+        {
+            var columnDef = group.Columns[i];
+            var column = BufferPool.GetColumn(columnDef with
+            {
+                RowGroup = group.RowGroupRef.RowGroup,
+            });
+            columns.Add(column);
+        }
+
+        var res = new MaterializedRowGroup(columns);
+        return res;
     }
 }

--- a/src/Database.Core/Execution/RowGroup.cs
+++ b/src/Database.Core/Execution/RowGroup.cs
@@ -41,7 +41,7 @@ public record RowGroup(
         for (var i = 0; i < numCol; i++)
         {
             var columnType = firstRow.Values[i]!.GetType();
-            columns.Add(IColumn.CreateColumn(columnType, $"col{i}", i, rows.Count));
+            columns.Add(IColumn.CreateColumn(columnType, $"col{i}", rows.Count));
             var values = (Array)columns[i].ValuesArray;
 
             for (var j = 0; j < rows.Count; j++)

--- a/src/Database.Core/Execution/RowGroup.cs
+++ b/src/Database.Core/Execution/RowGroup.cs
@@ -5,7 +5,7 @@ namespace Database.Core.Execution;
 public record RowGroup(
     int NumRows,
     RowGroupRef RowGroupRef,
-    List<ColumnRef> Columns
+    IReadOnlyList<ColumnRef> Columns
     )
 {
     public int NumColumns => Columns.Count;

--- a/src/Database.Core/Execution/RowGroup.cs
+++ b/src/Database.Core/Execution/RowGroup.cs
@@ -1,12 +1,68 @@
 namespace Database.Core.Execution;
 
-public record RowGroup(List<IColumn> Columns)
+public record RowGroup(
+    int NumRows,
+    RowGroupRef RowGroupRef,
+    List<ColumnRef> Columns
+    )
+{
+    public int NumColumns => Columns.Count;
+    // public int NumRows => rows.Count;
+
+    public List<Row> MaterializeRows()
+    {
+        var numRows = 0;
+        var rows = new List<Row>(numRows);
+        for (var i = 0; i < numRows; i++)
+        {
+            // rows.Add(new Row(new List<object?>(Columns.Count)));
+        }
+
+        // for (var i = 0; i < Columns.Count; i++)
+        // {
+        //     var column = Columns[i];
+        //
+        //     for (var j = 0; j < numRows; j++)
+        //     {
+        //         var row = rows[j];
+        //         row.Values.Add(column[j]);
+        //     }
+        // }
+        return rows;
+    }
+
+    public static RowGroup FromRows(IReadOnlyList<Row> rows)
+    {
+        throw new NotImplementedException();
+
+        var firstRow = rows[0];
+        var numCol = firstRow.Values.Count;
+        var columns = new List<IColumn>(numCol);
+        for (var i = 0; i < numCol; i++)
+        {
+            var columnType = firstRow.Values[i]!.GetType();
+            columns.Add(IColumn.CreateColumn(columnType, $"col{i}", i, rows.Count));
+            var values = (Array)columns[i].ValuesArray;
+
+            for (var j = 0; j < rows.Count; j++)
+            {
+                var row = rows[j];
+                values.SetValue(row.Values[i], j);
+            }
+        }
+        //return new RowGroup(columns);
+    }
+
+    // TODO add a version that takes a list of indexes
+}
+
+public record MaterializedRowGroup(List<IColumn> Columns)
 {
     public int NumRows => Columns[0].Length;
 
     public List<Row> MaterializeRows()
     {
-        var numRows = Columns[0].Length;
+        var numRows = NumRows;
         var rows = new List<Row>(numRows);
         for (var i = 0; i < numRows; i++)
         {
@@ -26,37 +82,16 @@ public record RowGroup(List<IColumn> Columns)
         return rows;
     }
 
-    public static RowGroup FromRows(IReadOnlyList<Row> rows)
-    {
-        var firstRow = rows[0];
-        var numCol = firstRow.Values.Count;
-        var columns = new List<IColumn>(numCol);
-        for (var i = 0; i < numCol; i++)
-        {
-            var columnType = firstRow.Values[i]!.GetType();
-            columns.Add(IColumn.CreateColumn(columnType, $"col{i}", i, rows.Count));
-            var values = (Array)columns[i].ValuesArray;
-
-            for (var j = 0; j < rows.Count; j++)
-            {
-                var row = rows[j];
-                values.SetValue(row.Values[i], j);
-            }
-        }
-        return new RowGroup(columns);
-    }
-
-    // TODO add a version that takes a list of indexes
 }
 
 public static class RowGroupExtensions
 {
-    public static List<Row> AsRowList(this List<RowGroup> rowGroups)
+    public static List<Row> AsRowList(this List<MaterializedRowGroup> rowGroups)
     {
         return rowGroups.AsRows().ToList();
     }
 
-    public static IEnumerable<Row> AsRows(this List<RowGroup> rowGroups)
+    public static IEnumerable<Row> AsRows(this List<MaterializedRowGroup> rowGroups)
     {
         foreach (var rowGroup in rowGroups)
         {

--- a/src/Database.Core/Expressions/BinaryExpression.cs
+++ b/src/Database.Core/Expressions/BinaryExpression.cs
@@ -4,7 +4,7 @@ using Database.Core.Functions;
 namespace Database.Core.Expressions;
 
 [DebuggerDisplay("{Left} {Operator} {Right}")]
-public record BinaryExpression(TokenType Operator, IExpression Left, IExpression Right) : BaseExpression
+public record BinaryExpression(TokenType Operator, BaseExpression Left, BaseExpression Right) : BaseExpression
 {
 
 }

--- a/src/Database.Core/Expressions/ExpressionInterepter.cs
+++ b/src/Database.Core/Expressions/ExpressionInterepter.cs
@@ -93,7 +93,7 @@ public class ExpressionInterpreter
         var column = ColumnHelper.CreateColumn(
             fun.ReturnType.ClrTypeFromDataType(),
             expr.Alias,
-            expr.BoundIndex,
+            expr.BoundOutputColumn.Column,
             outputArray
             );
         return column;

--- a/src/Database.Core/Expressions/ExpressionInterepter.cs
+++ b/src/Database.Core/Expressions/ExpressionInterepter.cs
@@ -6,7 +6,7 @@ namespace Database.Core.Expressions;
 
 public class ExpressionInterpreter
 {
-    public IColumn Execute(IExpression exp, RowGroup rowGroup)
+    public IColumn Execute(BaseExpression exp, RowGroup rowGroup)
     {
         if (exp is BinaryExpression be)
         {
@@ -37,11 +37,16 @@ public class ExpressionInterpreter
             return literal.MaterializeColumn(expectedRows);
         }
 
+        if (exp.BoundFunction == null)
+        {
+            throw new ExpressionEvaluationException($"expression does not have BoundFunction bound for evaluation. {exp}");
+        }
+
         throw new ExpressionEvaluationException($"expression {exp} is not supported for evaluation");
     }
 
     // Assumes the expression has already been bound
-    public IColumn Execute(IExpression expr, IFunction fun, IColumn left, IColumn right)
+    public IColumn Execute(BaseExpression expr, IFunction fun, IColumn left, IColumn right)
     {
         Array outputArray = null;
 
@@ -93,7 +98,6 @@ public class ExpressionInterpreter
         var column = ColumnHelper.CreateColumn(
             fun.ReturnType.ClrTypeFromDataType(),
             expr.Alias,
-            expr.BoundOutputColumn.Column,
             outputArray
             );
         return column;

--- a/src/Database.Core/Expressions/FunctionExpression.cs
+++ b/src/Database.Core/Expressions/FunctionExpression.cs
@@ -3,4 +3,4 @@ using System.Diagnostics;
 namespace Database.Core.Expressions;
 
 [DebuggerDisplay("{Name}({Args})}")]
-public record FunctionExpression(string Name, params IExpression[] Args) : BaseExpression;
+public record FunctionExpression(string Name, params BaseExpression[] Args) : BaseExpression();

--- a/src/Database.Core/Expressions/IExpression.cs
+++ b/src/Database.Core/Expressions/IExpression.cs
@@ -1,12 +1,19 @@
 using Database.Core.Catalog;
+using Database.Core.Execution;
 using Database.Core.Functions;
 
 namespace Database.Core.Expressions;
 
 public interface IExpression
 {
-    // Index of the expression in its output from the prior operator
-    public int BoundIndex { get; set; }
+    /// <summary>
+    /// The output location for the expression
+    /// If the expression is a simple select statement, this can also be the input column
+    /// Otherwise, a new column will be allocated in the buffer pool and written to.
+    /// Not all expressions will be bound, intermediate results from complex expressions
+    /// are not written back to the buffer pool atm.
+    /// </summary>
+    public ColumnRef BoundOutputColumn { get; set; }
 
     public DataType? BoundDataType { get; set; }
 
@@ -17,7 +24,7 @@ public interface IExpression
 
 public record BaseExpression : IExpression
 {
-    public int BoundIndex { get; set; } = -1;
+    public ColumnRef BoundOutputColumn { get; set; }
 
     public DataType? BoundDataType { get; set; }
 

--- a/src/Database.Core/Expressions/IExpression.cs
+++ b/src/Database.Core/Expressions/IExpression.cs
@@ -4,31 +4,18 @@ using Database.Core.Functions;
 
 namespace Database.Core.Expressions;
 
-public interface IExpression
+/// <summary>
+/// The output location for the expression
+/// If the expression is a simple select statement, this can also be the input column
+/// Otherwise, a new column will be allocated in the buffer pool and written to.
+/// Not all expressions will be bound, intermediate results from complex expressions
+/// are not written back to the buffer pool atm.
+/// </summary>
+public record BaseExpression(
+    ColumnRef BoundOutputColumn = default,
+    DataType? BoundDataType = null,
+    IFunction? BoundFunction = null,
+    string Alias = ""
+    )
 {
-    /// <summary>
-    /// The output location for the expression
-    /// If the expression is a simple select statement, this can also be the input column
-    /// Otherwise, a new column will be allocated in the buffer pool and written to.
-    /// Not all expressions will be bound, intermediate results from complex expressions
-    /// are not written back to the buffer pool atm.
-    /// </summary>
-    public ColumnRef BoundOutputColumn { get; set; }
-
-    public DataType? BoundDataType { get; set; }
-
-    public IFunction? BoundFunction { get; set; }
-
-    public string Alias { get; set; }
-}
-
-public record BaseExpression : IExpression
-{
-    public ColumnRef BoundOutputColumn { get; set; }
-
-    public DataType? BoundDataType { get; set; }
-
-    public IFunction? BoundFunction { get; set; }
-
-    public string Alias { get; set; } = string.Empty;
 }

--- a/src/Database.Core/Expressions/OrderingExpression.cs
+++ b/src/Database.Core/Expressions/OrderingExpression.cs
@@ -3,7 +3,7 @@ using System.Diagnostics;
 namespace Database.Core.Expressions;
 
 [DebuggerDisplay("{Expression} {Ascending ? \"ASC\" : \"DESC\"}")]
-public record OrderingExpression(IExpression Expression, bool Ascending = true) : BaseExpression
+public record OrderingExpression(BaseExpression Expression, bool Ascending = true) : BaseExpression
 {
 
 }

--- a/src/Database.Core/Functions/FunctionRegistry.cs
+++ b/src/Database.Core/Functions/FunctionRegistry.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.Contracts;
 using Database.Core.Catalog;
 using Database.Core.Expressions;
 
@@ -118,7 +119,8 @@ public class FunctionRegistry
         }));
     }
 
-    public IFunction BindFunction(string name, IExpression[] args)
+    [Pure]
+    public IFunction BindFunction(string name, BaseExpression[] args)
     {
         if (!_funcs.TryGetValue(name, out var func))
         {

--- a/src/Database.Core/Functions/FunctionRegistry.cs
+++ b/src/Database.Core/Functions/FunctionRegistry.cs
@@ -118,7 +118,7 @@ public class FunctionRegistry
         }));
     }
 
-    public IFunction BindFunction(string name, IExpression[] args, TableSchema table)
+    public IFunction BindFunction(string name, IExpression[] args)
     {
         if (!_funcs.TryGetValue(name, out var func))
         {

--- a/src/Database.Core/Functions/SelectFunction.cs
+++ b/src/Database.Core/Functions/SelectFunction.cs
@@ -1,14 +1,18 @@
+using Database.Core.BufferPool;
 using Database.Core.Catalog;
 using Database.Core.Execution;
 
 namespace Database.Core.Functions;
 
-public record SelectFunction(int Index, DataType ReturnType) : IFunction
+public record SelectFunction(ColumnRef ColumnRef, DataType ReturnType, ParquetPool BufferPool) : IFunction
 {
     public IColumn SelectColumn(RowGroup rowGroup)
     {
-        // TODO copy w/ new alias / bound index on the IColumn
-        return rowGroup.Columns[Index];
+        var column = BufferPool.GetColumn(ColumnRef with
+        {
+            RowGroup = rowGroup.RowGroupRef.RowGroup,
+        });
+        return column;
     }
 }
 

--- a/src/Database.Core/Functions/SelectFunction.cs
+++ b/src/Database.Core/Functions/SelectFunction.cs
@@ -16,7 +16,7 @@ public record SelectFunction(ColumnRef ColumnRef, DataType ReturnType, ParquetPo
     }
 }
 
-public record LiteralFunction(int Index, object Value, DataType ReturnType) : IFunction
+public record LiteralFunction(object Value, DataType ReturnType) : IFunction
 {
     public IColumn MaterializeColumn(int length)
     {
@@ -30,7 +30,6 @@ public record LiteralFunction(int Index, object Value, DataType ReturnType) : IF
         var column = ColumnHelper.CreateColumn(
             type,
             "foo",
-            Index,
             outputArray);
 
         return column;

--- a/src/Database.Core/Operations/Aggregate.cs
+++ b/src/Database.Core/Operations/Aggregate.cs
@@ -4,7 +4,7 @@ using Database.Core.Functions;
 
 namespace Database.Core.Operations;
 
-public record Aggregate(IOperation Source, List<IExpression> Expressions) : IOperation
+public record Aggregate(IOperation Source, IReadOnlyList<BaseExpression> Expressions) : IOperation
 {
     private bool _done = false;
 

--- a/src/Database.Core/Operations/Aggregate.cs
+++ b/src/Database.Core/Operations/Aggregate.cs
@@ -12,6 +12,8 @@ public record Aggregate(IOperation Source, List<IExpression> Expressions) : IOpe
 
     public RowGroup? Next()
     {
+        throw new NotImplementedException();
+        /**
         if (_done)
         {
             return null;
@@ -70,5 +72,6 @@ public record Aggregate(IOperation Source, List<IExpression> Expressions) : IOpe
 
         _done = true;
         return result;
+        **/
     }
 }

--- a/src/Database.Core/Operations/Distinct.cs
+++ b/src/Database.Core/Operations/Distinct.cs
@@ -8,6 +8,8 @@ public record Distinct(IOperation Source) : IOperation
 
     public RowGroup? Next()
     {
+        throw new NotImplementedException();
+        /**
         var rowGroup = Source.Next();
         if (rowGroup == null)
         {
@@ -40,7 +42,7 @@ public record Distinct(IOperation Source) : IOperation
 
         var uniqueList = _unique.ToList();
 
-        var result = new RowGroup(new List<IColumn>(numColumns));
+        var result = new RowGroup(new List<RowRef>(numColumns));
         for (var i = 0; i < numColumns; i++)
         {
             var columnType = columns[i].Type;
@@ -63,5 +65,6 @@ public record Distinct(IOperation Source) : IOperation
 
         // How do we determine the chunk size now?
         return result;
+        **/
     }
 }

--- a/src/Database.Core/Operations/Distinct.cs
+++ b/src/Database.Core/Operations/Distinct.cs
@@ -1,15 +1,23 @@
+using Database.Core.BufferPool;
+using Database.Core.Catalog;
 using Database.Core.Execution;
+using Database.Core.Expressions;
 
 namespace Database.Core.Operations;
 
-public record Distinct(IOperation Source) : IOperation
+public record Distinct(
+    ParquetPool BufferPool,
+    MemoryBasedTable MemoryTable,
+    IOperation Source,
+    IReadOnlyList<BaseExpression> Expressions,
+    List<ColumnSchema> OutputColumns,
+    List<ColumnRef> OutputColumnRefs
+    ) : IOperation
 {
     private HashSet<Row> _unique = null;
 
     public RowGroup? Next()
     {
-        throw new NotImplementedException();
-        /**
         var rowGroup = Source.Next();
         if (rowGroup == null)
         {
@@ -27,7 +35,7 @@ public record Distinct(IOperation Source) : IOperation
 
             while (rowGroup != null)
             {
-                foreach (var row in rowGroup.MaterializeRows())
+                foreach (var row in rowGroup.MaterializeRows(BufferPool))
                 {
                     _unique.Add(row);
                 }
@@ -41,30 +49,29 @@ public record Distinct(IOperation Source) : IOperation
         }
 
         var uniqueList = _unique.ToList();
+        var targetRowGroup = MemoryTable.AddRowGroup();
 
-        var result = new RowGroup(new List<RowRef>(numColumns));
         for (var i = 0; i < numColumns; i++)
         {
-            var columnType = columns[i].Type;
+            var outputColumn = OutputColumns[i];
+            var columnType = outputColumn.ClrType;
             var values = Array.CreateInstance(columnType, uniqueList.Count);
 
             for (var j = 0; j < uniqueList.Count; j++)
             {
                 var row = uniqueList[j];
-                values.SetValue(Convert.ChangeType(row.Values[i], columnType), j);
+                values.SetValue(row.Values[i], j);
             }
 
             var column = ColumnHelper.CreateColumn(
                 columnType,
-                $"{i}.{columnType}",
-                i,
+                outputColumn.Name,
                 values
             );
-            result.Columns.Add(column);
+
+            BufferPool.WriteColumn(outputColumn.ColumnRef, column, targetRowGroup.RowGroup);
         }
 
-        // How do we determine the chunk size now?
-        return result;
-        **/
+        return new RowGroup(uniqueList.Count, targetRowGroup, OutputColumnRefs);
     }
 }

--- a/src/Database.Core/Operations/FileScan.cs
+++ b/src/Database.Core/Operations/FileScan.cs
@@ -5,12 +5,12 @@ using Parquet.Schema;
 
 namespace Database.Core.Operations;
 
-public record FileScan(ParquetPool BufferPool, string Path) : IOperation
+public record FileScan(ParquetPool BufferPool, string Path, Catalog.Catalog Catalog) : IOperation
 {
     private ParquetReader? _reader = null;
     private int _group = -1;
-    private DataField[] _dataFields;
     private bool _done = false;
+    private ParquetFileHandle _handle;
 
     public RowGroup? Next()
     {
@@ -21,9 +21,8 @@ public record FileScan(ParquetPool BufferPool, string Path) : IOperation
 
         if (_reader == null)
         {
-            var handle = BufferPool.OpenFile(Path);
-            _reader = handle.Reader;
-            _dataFields = handle.DataFields;
+            _handle = BufferPool.OpenFile(Path);
+            _reader = _handle.Reader;
         }
 
         _group++;
@@ -35,19 +34,13 @@ public record FileScan(ParquetPool BufferPool, string Path) : IOperation
 
         var rg = _reader.OpenRowGroupReader(_group);
 
-        var columnValues = new List<IColumn>(_dataFields.Length);
+        var table = Catalog.GetTableByPath(Path);
+        var columnRefs = table.Columns.Select(c => c.ColumnRef).ToList();
 
-        for (var i = 0; i < _dataFields.Length; i++)
-        {
-            var field = _dataFields[i];
-            var column = rg.ReadColumnAsync(field).GetAwaiter().GetResult();
-            var (targetType, finalCopy) = TypeConversion.RemoveNullablesHack(column, field);
-
-            var obj = ColumnHelper.CreateColumn(targetType, field.Name, i, finalCopy);
-
-            columnValues.Add(obj);
-        }
-
-        return new RowGroup(columnValues);
+        return new RowGroup(
+            (int)rg.RowCount,
+            new RowGroupRef(_group),
+            columnRefs
+        );
     }
 }

--- a/src/Database.Core/Operations/FileScan.cs
+++ b/src/Database.Core/Operations/FileScan.cs
@@ -1,11 +1,15 @@
 using Database.Core.BufferPool;
+using Database.Core.Catalog;
 using Database.Core.Execution;
 using Parquet;
 using Parquet.Schema;
 
 namespace Database.Core.Operations;
 
-public record FileScan(ParquetPool BufferPool, string Path, Catalog.Catalog Catalog) : IOperation
+public record FileScan(
+    ParquetPool BufferPool,
+    string Path,
+    IReadOnlyList<ColumnRef> OutputColumnRefs) : IOperation
 {
     private ParquetReader? _reader = null;
     private int _group = -1;
@@ -34,13 +38,10 @@ public record FileScan(ParquetPool BufferPool, string Path, Catalog.Catalog Cata
 
         var rg = _reader.OpenRowGroupReader(_group);
 
-        var table = Catalog.GetTableByPath(Path);
-        var columnRefs = table.Columns.Select(c => c.ColumnRef).ToList();
-
         return new RowGroup(
             (int)rg.RowCount,
             new RowGroupRef(_group),
-            columnRefs
+            OutputColumnRefs
         );
     }
 }

--- a/src/Database.Core/Operations/Filter.cs
+++ b/src/Database.Core/Operations/Filter.cs
@@ -97,7 +97,6 @@ public record Filter(
                 BufferPool.WriteColumn(outputRef, column, targetRowGroup.RowGroup);
             }
 
-
             // Are there scenarios where using a mask would be better than doing the copy?
             // This would require the rest of the pipeline be filter aware however
             // which increases the code complexity

--- a/src/Database.Core/Operations/Filter.cs
+++ b/src/Database.Core/Operations/Filter.cs
@@ -9,7 +9,7 @@ public record Filter(
     ParquetPool BufferPool,
     MemoryBasedTable MemoryTable,
     IOperation Source,
-    IExpression Expression,
+    BaseExpression Expression,
     List<ColumnRef> OutputColumns
     ) : IOperation
 {
@@ -90,7 +90,6 @@ public record Filter(
                 var column = ColumnHelper.CreateColumn(
                     columnType,
                     sourceColumn.Name,
-                    i,
                     values);
                 column.SetValues(sourceColumn.ValuesArray, keep);
 

--- a/src/Database.Core/Operations/Filter.cs
+++ b/src/Database.Core/Operations/Filter.cs
@@ -1,10 +1,17 @@
+using Database.Core.BufferPool;
 using Database.Core.Execution;
 using Database.Core.Expressions;
 using Database.Core.Functions;
 
 namespace Database.Core.Operations;
 
-public record Filter(IOperation Source, IExpression Expression) : IOperation
+public record Filter(
+    ParquetPool BufferPool,
+    MemoryBasedTable MemoryTable,
+    IOperation Source,
+    IExpression Expression,
+    List<ColumnRef> OutputColumns
+    ) : IOperation
 {
     private bool _done = false;
 
@@ -29,10 +36,13 @@ public record Filter(IOperation Source, IExpression Expression) : IOperation
             var res = (Column<bool>)_interpreter.Execute(Expression, next);
             var keep = res.Values;
 
-            int count = 0;
+            var count = 0;
             for (var i = 0; i < keep.Length; i++)
             {
-                count += keep[i] ? 1 : 0;
+                if (keep[i])
+                {
+                    count++;
+                }
             }
 
             if (count == 0)
@@ -40,31 +50,63 @@ public record Filter(IOperation Source, IExpression Expression) : IOperation
                 // filtered all rows out, try to obtain the next batch
                 continue;
             }
-            if (next.NumRows == count)
+
+            // TODO think about how we want to deal with columns/rowgroups from separate tables
+            // if (next.NumRows == count)
+            // {
+            //     // No filtering necessary
+            //     return next;
+            // }
+
+            var columns = next.Columns;
+            // TODO allocate a new one?
+            var sourceRowGroup = next.RowGroupRef.RowGroup;
+            var targetRowGroup = MemoryTable.AddRowGroup();
+
+            if (next.Columns.Count != OutputColumns.Count)
             {
-                // No filtering necessary
-                return next;
+                var got = string.Join(", ", next.Columns);
+                var expected = string.Join(", ", OutputColumns);
+
+                var gotSet = new HashSet<ColumnRef>(next.Columns);
+                var expectedSet = new HashSet<ColumnRef>(OutputColumns);
+                var additional = string.Join(", ", gotSet.Except(expectedSet));
+                var missing = string.Join(", ", expectedSet.Except(gotSet));
+
+                throw new Exception($"Filter output columns do not match input columns. " +
+                                    $"Got {next.Columns.Count} Expected {OutputColumns.Count}\n" +
+                                    $"Additional: {additional}\n" +
+                                    $"Missing: {missing}\n" +
+                                    $"Got: {got}\n" +
+                                    $"Expected: {expected}");
             }
 
-            var numColumns = next.Columns.Count;
-            var columns = next.Columns;
-            var result = new RowGroup(new List<IColumn>(numColumns));
-            for (var i = 0; i < numColumns; i++)
+            for (var i = 0; i < next.Columns.Count; i++)
             {
-                var columnType = columns[i].Type;
+                var sourceColumn = BufferPool.GetColumn(columns[i] with { RowGroup = sourceRowGroup });
+                var columnType = sourceColumn.Type;
+
                 var values = Array.CreateInstance(columnType, count);
                 var column = ColumnHelper.CreateColumn(
                     columnType,
-                    columns[i].Name,
+                    sourceColumn.Name,
                     i,
-                    values
-                );
+                    values);
+                column.SetValues(sourceColumn.ValuesArray, keep);
 
-                column.SetValues(next.Columns[i].ValuesArray, keep);
-                result.Columns.Add(column);
+                var outputRef = OutputColumns[i];
+                BufferPool.WriteColumn(outputRef, column, targetRowGroup.RowGroup);
             }
 
-            return result;
+
+            // Are there scenarios where using a mask would be better than doing the copy?
+            // This would require the rest of the pipeline be filter aware however
+            // which increases the code complexity
+            return new RowGroup(
+                count,
+                targetRowGroup,
+                OutputColumns
+                );
         }
     }
 }

--- a/src/Database.Core/Operations/HashAggregate.cs
+++ b/src/Database.Core/Operations/HashAggregate.cs
@@ -1,3 +1,5 @@
+using System.Text.RegularExpressions;
+using Database.Core.BufferPool;
 using Database.Core.Catalog;
 using Database.Core.Execution;
 using Database.Core.Expressions;
@@ -5,7 +7,18 @@ using Database.Core.Functions;
 
 namespace Database.Core.Operations;
 
-public record HashAggregate(IOperation Source, IReadOnlyList<BaseExpression> Expressions, List<BaseExpression> GroupingExpressions) : IOperation
+public record HashAggregate(
+    ParquetPool BufferPool,
+    IOperation Source,
+    MemoryBasedTable GroupingTable,
+    List<BaseExpression> OutputExpressions, // grouping columns + aggregates
+    List<ColumnSchema> OutputColumns,
+    List<ColumnRef> OutputColumnRefs,
+    MemoryBasedTable OutputTable2,
+    List<BaseExpression> OutputExpressions2, // projection expressions
+    List<ColumnSchema> OutputColumns2,
+    List<ColumnRef> OutputColumnRefs2
+    ) : IOperation
 {
     private bool _done = false;
 
@@ -13,15 +26,17 @@ public record HashAggregate(IOperation Source, IReadOnlyList<BaseExpression> Exp
 
     public RowGroup? Next()
     {
-        throw new NotFiniteNumberException();
-        /**
         if (_done)
         {
             return null;
         }
 
-        var aggregates = Expressions
+        var aggregates = OutputExpressions
             .Where(e => e.BoundFunction is IAggregateFunction)
+            .ToList();
+
+        var groupingExpressions = OutputExpressions
+            .Where(e => e.BoundFunction is not IAggregateFunction)
             .ToList();
 
         var rowGroup = Source.Next();
@@ -34,12 +49,12 @@ public record HashAggregate(IOperation Source, IReadOnlyList<BaseExpression> Exp
             var groupingKeys = new List<Row>(rowGroup.NumRows);
             for (var i = 0; i < rowGroup.NumRows; i++)
             {
-                groupingKeys.Add(new Row(new List<object?>(GroupingExpressions.Count)));
+                groupingKeys.Add(new Row(new List<object?>(groupingExpressions.Count)));
             }
 
-            for (var g = 0; g < GroupingExpressions.Count; g++)
+            for (var g = 0; g < groupingExpressions.Count; g++)
             {
-                var expression = GroupingExpressions[g];
+                var expression = groupingExpressions[g];
                 var column = _interpreter.Execute(expression, rowGroup);
                 for (var i = 0; i < column.Length; i++)
                 {
@@ -93,27 +108,18 @@ public record HashAggregate(IOperation Source, IReadOnlyList<BaseExpression> Exp
         }
 
         var resRows = hashToAggState.ToList();
-        var rows = resRows.Select(kvp => kvp.Key).ToList();
-        var groupedRowGroup = RowGroup.FromRows(rows);
+        var groupedRowGroup = FromRows(resRows);
+
+        var outputRowGroup = OutputTable2.AddRowGroup();
 
         var aggIdx = 0;
-        // create empty rowgroup we'll fill in below
-        var result = new RowGroup(new List<RowRef>(Expressions.Count));
-        for (var i = 0; i < Expressions.Count; i++)
-        {
-            var expression = Expressions[i];
-            var fun = expression.BoundFunction!;
-            var dataType = fun.ReturnType.ClrTypeFromDataType();
-            var valuesArray = Array.CreateInstance(dataType, resRows.Count);
-            var column = ColumnHelper.CreateColumn(dataType, expression.Alias, i, valuesArray);
-            result.Columns.Add(column);
-        }
 
-        // Fill in the rowgroup with the aggregate results
-        for (var i = 0; i < Expressions.Count; i++)
+        // TODO I think I can remove the projection here entirely now
+        for (var i = 0; i < OutputExpressions2.Count; i++)
         {
-            var expression = Expressions[i];
-            var column = result.Columns[i];
+            var expression = OutputExpressions2[i];
+            var columnSchema = OutputColumns2[i];
+            var column = IColumn.CreateColumn(columnSchema.ClrType, columnSchema.Name, resRows.Count);
             var values = column.ValuesArray;
 
             if (expression.BoundFunction is IAggregateFunction aggFn)
@@ -132,10 +138,66 @@ public record HashAggregate(IOperation Source, IReadOnlyList<BaseExpression> Exp
                 var columnRes = _interpreter.Execute(expression, groupedRowGroup);
                 Array.Copy(columnRes.ValuesArray, values, columnRes.Length);
             }
+
+            BufferPool.WriteColumn(columnSchema.ColumnRef, column, outputRowGroup.RowGroup);
         }
 
         _done = true;
-        return result;
-        **/
+
+        return new RowGroup(
+            groupedRowGroup.NumRows,
+            outputRowGroup,
+            OutputColumnRefs2);
+    }
+
+    private RowGroup FromRows(List<KeyValuePair<Row, List<IAggregateState>>> resRows)
+    {
+        var rows = resRows.Select(kvp => kvp.Key).ToList();
+        var targetRowGroup = GroupingTable.AddRowGroup();
+        var groupingIdx = 0;
+        var aggIdx = 0;
+
+        for (var i = 0; i < OutputExpressions.Count; i++)
+        {
+            var expression = OutputExpressions[i];
+            var columnSchema = OutputColumns[i];
+            var columnRef = columnSchema.ColumnRef;
+            var columnType = columnSchema.ClrType;
+            var values = Array.CreateInstance(columnType, rows.Count);
+
+            if (expression.BoundFunction is IAggregateFunction aggFn)
+            {
+                for (var j = 0; j < resRows.Count; j++)
+                {
+                    var (key, states) = resRows[j];
+                    var state = states[aggIdx];
+                    var value = aggFn.GetValue(state);
+                    values.SetValue(value, j);
+                }
+                aggIdx++;
+            }
+            else
+            {
+                for (var j = 0; j < rows.Count; j++)
+                {
+                    var row = rows[j];
+                    values.SetValue(row.Values[groupingIdx], j);
+                }
+
+                groupingIdx++;
+            }
+
+            var column = ColumnHelper.CreateColumn(
+                columnType,
+                columnSchema.Name,
+                values
+            );
+            BufferPool.WriteColumn(columnRef, column, targetRowGroup.RowGroup);
+        }
+
+
+
+
+        return new RowGroup(rows.Count, targetRowGroup, OutputColumnRefs);
     }
 }

--- a/src/Database.Core/Operations/HashAggregate.cs
+++ b/src/Database.Core/Operations/HashAggregate.cs
@@ -5,7 +5,7 @@ using Database.Core.Functions;
 
 namespace Database.Core.Operations;
 
-public record HashAggregate(IOperation Source, List<IExpression> Expressions, List<IExpression> GroupingExpressions) : IOperation
+public record HashAggregate(IOperation Source, IReadOnlyList<BaseExpression> Expressions, List<BaseExpression> GroupingExpressions) : IOperation
 {
     private bool _done = false;
 

--- a/src/Database.Core/Operations/HashAggregate.cs
+++ b/src/Database.Core/Operations/HashAggregate.cs
@@ -13,6 +13,8 @@ public record HashAggregate(IOperation Source, List<IExpression> Expressions, Li
 
     public RowGroup? Next()
     {
+        throw new NotFiniteNumberException();
+        /**
         if (_done)
         {
             return null;
@@ -96,7 +98,7 @@ public record HashAggregate(IOperation Source, List<IExpression> Expressions, Li
 
         var aggIdx = 0;
         // create empty rowgroup we'll fill in below
-        var result = new RowGroup(new List<IColumn>(Expressions.Count));
+        var result = new RowGroup(new List<RowRef>(Expressions.Count));
         for (var i = 0; i < Expressions.Count; i++)
         {
             var expression = Expressions[i];
@@ -134,5 +136,6 @@ public record HashAggregate(IOperation Source, List<IExpression> Expressions, Li
 
         _done = true;
         return result;
+        **/
     }
 }

--- a/src/Database.Core/Operations/Projection.cs
+++ b/src/Database.Core/Operations/Projection.cs
@@ -6,7 +6,11 @@ using Database.Core.Functions;
 
 namespace Database.Core.Operations;
 
-public record Projection(ParquetPool BufferPool, IOperation Source, IReadOnlyList<BaseExpression> Expressions) : IOperation
+public record Projection(
+    ParquetPool BufferPool,
+    MemoryBasedTable MemoryTable,
+    IOperation Source,
+    IReadOnlyList<BaseExpression> Expressions) : IOperation
 {
     private ExpressionInterpreter _interpreter = new();
 
@@ -25,13 +29,6 @@ public record Projection(ParquetPool BufferPool, IOperation Source, IReadOnlyLis
         {
             var expr = Expressions[i];
             var fun = expr.BoundFunction!;
-
-            // Select function references existing data, return a pointer to it
-            if (fun is SelectFunction sel)
-            {
-                newColumns.Add(sel.ColumnRef);
-                continue;
-            }
 
             // Other functions will need to be materialized
             // Drop them into the buffer pool

--- a/src/Database.Core/Operations/Projection.cs
+++ b/src/Database.Core/Operations/Projection.cs
@@ -1,12 +1,14 @@
+using Database.Core.BufferPool;
 using Database.Core.Catalog;
 using Database.Core.Execution;
 using Database.Core.Expressions;
+using Database.Core.Functions;
 
 namespace Database.Core.Operations;
 
-public record Projection(TableSchema Schema, IOperation Source, List<IExpression> Expressions) : IOperation
+public record Projection(ParquetPool BufferPool, IOperation Source, List<IExpression> Expressions) : IOperation
 {
-    private ExpressionInterpreter _interpreter = new ExpressionInterpreter();
+    private ExpressionInterpreter _interpreter = new();
 
     public RowGroup? Next()
     {
@@ -16,13 +18,23 @@ public record Projection(TableSchema Schema, IOperation Source, List<IExpression
             return null;
         }
 
-        var newColumns = new List<IColumn>(Expressions.Count);
+        var newColumns = new List<ColumnRef>(Expressions.Count);
+        var group = rowGroup.RowGroupRef.RowGroup;
 
         for (var i = 0; i < Expressions.Count; i++)
         {
             var expr = Expressions[i];
             var fun = expr.BoundFunction!;
 
+            // Select function references existing data, return a pointer to it
+            if (fun is SelectFunction sel)
+            {
+                newColumns.Add(sel.ColumnRef);
+                continue;
+            }
+
+            // Other functions will need to be materialized
+            // Drop them into the buffer pool
             var columnRes = _interpreter.Execute(expr, rowGroup);
             var column = ColumnHelper.CreateColumn(
                 fun.ReturnType.ClrTypeFromDataType(),
@@ -30,10 +42,15 @@ public record Projection(TableSchema Schema, IOperation Source, List<IExpression
                 i,
                 columnRes.ValuesArray
             );
-            newColumns.Add(column);
+            var columnRef = expr.BoundOutputColumn;
+            BufferPool.WriteColumn(columnRef, column, group);
+            newColumns.Add(columnRef);
         }
 
-        var newRowGroup = new RowGroup(newColumns);
-        return newRowGroup;
+        return new RowGroup(
+            rowGroup.NumRows,
+            rowGroup.RowGroupRef,
+            newColumns
+            );
     }
 }

--- a/src/Database.Core/Operations/Projection.cs
+++ b/src/Database.Core/Operations/Projection.cs
@@ -6,7 +6,7 @@ using Database.Core.Functions;
 
 namespace Database.Core.Operations;
 
-public record Projection(ParquetPool BufferPool, IOperation Source, List<IExpression> Expressions) : IOperation
+public record Projection(ParquetPool BufferPool, IOperation Source, IReadOnlyList<BaseExpression> Expressions) : IOperation
 {
     private ExpressionInterpreter _interpreter = new();
 
@@ -39,7 +39,6 @@ public record Projection(ParquetPool BufferPool, IOperation Source, List<IExpres
             var column = ColumnHelper.CreateColumn(
                 fun.ReturnType.ClrTypeFromDataType(),
                 expr.Alias,
-                i,
                 columnRes.ValuesArray
             );
             var columnRef = expr.BoundOutputColumn;

--- a/src/Database.Core/Operations/ProjectionBinaryEval.cs
+++ b/src/Database.Core/Operations/ProjectionBinaryEval.cs
@@ -1,3 +1,4 @@
+using Database.Core.BufferPool;
 using Database.Core.Catalog;
 using Database.Core.Execution;
 using Database.Core.Expressions;
@@ -5,7 +6,7 @@ using Database.Core.Functions;
 
 namespace Database.Core.Operations;
 
-public class ProjectionBinaryEval(TableSchema Schema, IOperation Source, List<IExpression> expressions) : IOperation
+public class ProjectionBinaryEval(ParquetPool BufferPool, IOperation Source, List<IExpression> expressions) : IOperation
 {
     private ExpressionInterpreter _interpreter = new ExpressionInterpreter();
 
@@ -16,13 +17,9 @@ public class ProjectionBinaryEval(TableSchema Schema, IOperation Source, List<IE
         {
             return null;
         }
-        var newColumns = new List<IColumn>(Schema.Columns.Count);
-        var nonExpressionColumns = Schema.Columns.Count - expressions.Count;
-        for (var i = 0; i < nonExpressionColumns; i++)
-        {
-            var column = next.Columns[i];
-            newColumns.Add(column);
-        }
+
+        var newColumns = new List<ColumnRef>(next.Columns);
+        var rowGroup = next.RowGroupRef.RowGroup;
 
         for (var i = 0; i < expressions.Count; i++)
         {
@@ -30,18 +27,22 @@ public class ProjectionBinaryEval(TableSchema Schema, IOperation Source, List<IE
             var fun = expr.BoundFunction!;
 
             var columnRes = _interpreter.Execute(expr, next);
-
-            var columnInSchema = Schema.Columns[nonExpressionColumns + i];
             var column = ColumnHelper.CreateColumn(
                 fun.ReturnType.ClrTypeFromDataType(),
-                columnInSchema.Name,
+                expr.Alias,
                 i,
                 columnRes.ValuesArray
             );
-            newColumns.Add((IColumn)column);
+
+            var columnRef = expr.BoundOutputColumn;
+            BufferPool.WriteColumn(columnRef, column, rowGroup);
+            newColumns.Add(columnRef);
         }
 
-        var newRowGroup = new RowGroup(newColumns);
-        return newRowGroup;
+        return new RowGroup(
+            next.NumRows,
+            next.RowGroupRef,
+            newColumns
+        );
     }
 }

--- a/src/Database.Core/Operations/ProjectionBinaryEval.cs
+++ b/src/Database.Core/Operations/ProjectionBinaryEval.cs
@@ -6,13 +6,13 @@ using Database.Core.Functions;
 
 namespace Database.Core.Operations;
 
-public class ProjectionBinaryEval(ParquetPool BufferPool, IOperation Source, List<IExpression> expressions) : IOperation
+public class ProjectionBinaryEval(ParquetPool bufferPool, IOperation source, List<BaseExpression> expressions) : IOperation
 {
     private ExpressionInterpreter _interpreter = new ExpressionInterpreter();
 
     public RowGroup? Next()
     {
-        var next = Source.Next();
+        var next = source.Next();
         if (next is null)
         {
             return null;
@@ -30,12 +30,11 @@ public class ProjectionBinaryEval(ParquetPool BufferPool, IOperation Source, Lis
             var column = ColumnHelper.CreateColumn(
                 fun.ReturnType.ClrTypeFromDataType(),
                 expr.Alias,
-                i,
                 columnRes.ValuesArray
             );
 
             var columnRef = expr.BoundOutputColumn;
-            BufferPool.WriteColumn(columnRef, column, rowGroup);
+            bufferPool.WriteColumn(columnRef, column, rowGroup);
             newColumns.Add(columnRef);
         }
 

--- a/src/Database.Core/Planner/ConstantFolding.cs
+++ b/src/Database.Core/Planner/ConstantFolding.cs
@@ -1,0 +1,97 @@
+using Database.Core.Expressions;
+using static Database.Core.TokenType;
+
+namespace Database.Core.Planner;
+
+public static class ConstantFolding
+{
+    public static SelectStatement Fold(SelectStatement select)
+    {
+        var newStatements = new List<BaseExpression>(select.SelectList.Expressions.Count);
+
+        var expressions = select.SelectList.Expressions;
+        foreach (var expr in expressions)
+        {
+            newStatements.Add(Fold(expr));
+        }
+
+        var where = select.Where;
+        if (where != null)
+        {
+            where = Fold(where);
+        }
+
+        return select with
+        {
+            SelectList = select.SelectList with { Expressions = newStatements },
+            Where = where,
+        };
+    }
+
+    public static BaseExpression Fold(BaseExpression expr)
+    {
+        if (expr is BinaryExpression b)
+        {
+            var left = Fold(b.Left);
+            var right = Fold(b.Right);
+
+            if (left is IntegerLiteral li && right is IntegerLiteral ri)
+            {
+                var result = b.Operator switch
+                {
+                    PLUS => li.Literal + ri.Literal,
+                    MINUS => li.Literal - ri.Literal,
+                    STAR => li.Literal * ri.Literal,
+                    SLASH => li.Literal / ri.Literal,
+                    PERCENT => li.Literal % ri.Literal,
+                    _ => throw new QueryPlanException($"Operator '{b.Operator}' not supported for constant folding")
+                };
+                return new IntegerLiteral(result);
+            }
+            if (left is DoubleLiteral ld && right is DoubleLiteral rd)
+            {
+                var result = b.Operator switch
+                {
+                    PLUS => ld.Literal + rd.Literal,
+                    MINUS => ld.Literal - rd.Literal,
+                    STAR => ld.Literal * rd.Literal,
+                    SLASH => ld.Literal / rd.Literal,
+                    PERCENT => ld.Literal % ld.Literal,
+                    _ => throw new QueryPlanException($"Operator '{b.Operator}' not supported for constant folding")
+                };
+                return new DoubleLiteral(result);
+            }
+            if (left is DateTimeLiteral ldt && right is IntervalLiteral ril)
+            {
+                var result = b.Operator switch
+                {
+                    PLUS => ldt.Literal + ril.Literal,
+                    MINUS => ldt.Literal - ril.Literal,
+                    _ => throw new QueryPlanException($"Operator '{b.Operator}' not supported for constant folding")
+                };
+                return new DateTimeLiteral(result);
+            }
+
+            return b with
+            {
+                Left = left,
+                Right = right,
+            };
+        }
+
+        if (expr is FunctionExpression f)
+        {
+            var args = new List<BaseExpression>(f.Args.Length);
+            foreach (var arg in f.Args)
+            {
+                args.Add(Fold(arg));
+            }
+            return f with
+            {
+                Args = args.ToArray(),
+            };
+        }
+
+        return expr;
+    }
+}

--- a/src/Database.Core/Planner/ExpressionBinder.cs
+++ b/src/Database.Core/Planner/ExpressionBinder.cs
@@ -173,7 +173,8 @@ public class ExpressionBinder(ParquetPool bufferPool, FunctionRegistry functions
             var col = columns.SingleOrDefault(c => c.Name == column.Column);
             if (col == null)
             {
-                throw new QueryPlanException($"Column '{column.Column}' does not exist on table");
+                var columnNames = string.Join(", ", columns.Select(c => c.Name));
+                throw new QueryPlanException($"Column '{column.Column}' was not found in list of available columns {columnNames}");
             }
 
             return (column.Column, col.ColumnRef, col.DataType);

--- a/src/Database.Core/Planner/ExpressionBinder.cs
+++ b/src/Database.Core/Planner/ExpressionBinder.cs
@@ -1,0 +1,204 @@
+using System.Diagnostics.Contracts;
+using Database.Core.BufferPool;
+using Database.Core.Catalog;
+using Database.Core.Execution;
+using Database.Core.Expressions;
+using Database.Core.Functions;
+using static Database.Core.TokenType;
+
+namespace Database.Core.Planner;
+
+public class ExpressionBinder(ParquetPool bufferPool, FunctionRegistry functions)
+{
+    [Pure]
+    public IReadOnlyList<BaseExpression> Bind(
+        IReadOnlyList<BaseExpression> expressions,
+        IReadOnlyList<ColumnSchema> columns
+    )
+    {
+        var result = new List<BaseExpression>(expressions.Count);
+        foreach (var expr in expressions)
+        {
+            result.Add(Bind(expr, columns));
+        }
+        return result;
+    }
+
+    [Pure]
+    public BaseExpression Bind(
+        BaseExpression expression,
+        IReadOnlyList<ColumnSchema> columns
+        )
+    {
+        var fun = FunctionForExpression(expression, columns);
+        var alias = expression.Alias;
+        if (expression is BinaryExpression b && alias == "")
+        {
+            alias = b.Operator.ToString(); // TODO literal of the expression
+        }
+
+        expression = expression with
+        {
+            BoundFunction = fun,
+            BoundDataType = fun.ReturnType,
+            Alias = alias,
+        };
+
+        if (expression is BinaryExpression be)
+        {
+            return be with
+            {
+                Left = Bind(be.Left, columns),
+                Right = Bind(be.Right, columns),
+            };
+        }
+
+        if (expression is FunctionExpression fn)
+        {
+            var boundArgs = new BaseExpression[fn.Args.Length];
+            for (var i = 0; i < fn.Args.Length; i++)
+            {
+                boundArgs[i] = Bind(fn.Args[i], columns);
+            }
+
+            return fn with
+            {
+                Args = boundArgs,
+            };
+        }
+
+        return expression;
+    }
+
+    [Pure]
+    public IFunction FunctionForExpression(
+        BaseExpression expression,
+        IReadOnlyList<ColumnSchema> columns
+        )
+    {
+        if (expression.BoundFunction != null)
+        {
+            return expression.BoundFunction;
+        }
+
+        if (expression is IntegerLiteral numInt)
+        {
+            return new LiteralFunction(numInt.Literal, DataType.Int);
+        }
+
+        if (expression is DoubleLiteral num)
+        {
+            return new LiteralFunction(num.Literal, DataType.Double);
+        }
+
+        if (expression is StringLiteral str)
+        {
+            return new LiteralFunction(str.Literal, DataType.String);
+        }
+
+        if (expression is BoolLiteral b)
+        {
+            return new LiteralFunction(b.Literal, DataType.Bool);
+        }
+
+        if (expression is DateLiteral d)
+        {
+            return new LiteralFunction(d.Literal, DataType.Date);
+        }
+
+        if (expression is DateTimeLiteral dt)
+        {
+            return new LiteralFunction(dt.Literal, DataType.DateTime);
+        }
+
+        if (expression is IntervalLiteral il)
+        {
+            return new LiteralFunction(il.Literal, DataType.Interval);
+        }
+
+        if (expression is ColumnExpression column)
+        {
+            var (_, index, colType) = FindColumnIndex(columns, column);
+            return new SelectFunction(index, colType!.Value, bufferPool);
+        }
+
+        if (expression is BinaryExpression be)
+        {
+            var left = Bind(be.Left, columns);
+            var right = Bind(be.Right, columns);
+
+            if (left.BoundDataType == null || left.BoundDataType != right.BoundDataType)
+            {
+                // TODO automatic type casts?
+                throw new QueryPlanException(
+                    $"left and right expression types do not match. got {left.BoundDataType} != {right.BoundDataType}");
+            }
+
+            var args = new[] { left, right };
+            return (be.Operator) switch
+            {
+                EQUAL => functions.BindFunction("=", args),
+                GREATER => functions.BindFunction(">", args),
+                GREATER_EQUAL => functions.BindFunction(">=", args),
+                LESS => functions.BindFunction("<", args),
+                LESS_EQUAL => functions.BindFunction("<=", args),
+                STAR => functions.BindFunction("*", args),
+                PLUS => functions.BindFunction("+", args),
+                MINUS => functions.BindFunction("-", args),
+                SLASH => functions.BindFunction("/", args),
+                PERCENT => functions.BindFunction("%", args),
+                _ => throw new QueryPlanException($"operator '{be.Operator}' not setup for binding yet"),
+            };
+        }
+
+        if (expression is FunctionExpression fn)
+        {
+            var boundArgs = new BaseExpression[fn.Args.Length];
+            for (var i = 0; i < fn.Args.Length; i++)
+            {
+                boundArgs[i] = Bind(fn.Args[i], columns);
+            }
+            return functions.BindFunction(fn.Name, boundArgs);
+        }
+
+        if (expression is StarExpression)
+        {
+            // TODO this is a bit of a hack
+            return new LiteralFunction(1, DataType.Int);
+        }
+
+        throw new NotImplementedException($"unsupported expression type '{expression.GetType().Name}' for expression binding");
+    }
+
+    private static (string, ColumnRef, DataType?) FindColumnIndex(IReadOnlyList<ColumnSchema> columns, BaseExpression exp)
+    {
+        if (exp.BoundOutputColumn != default)
+        {
+            return (exp.Alias, exp.BoundOutputColumn, exp.BoundDataType);
+        }
+
+        // TODO we need to actually handle * and alias
+        if (exp is ColumnExpression column)
+        {
+            var col = columns.SingleOrDefault(c => c.Name == column.Column);
+            if (col == null)
+            {
+                throw new QueryPlanException($"Column '{column.Column}' does not exist on table");
+            }
+
+            return (column.Column, col.ColumnRef, col.DataType);
+        }
+        if (exp is FunctionExpression fun)
+        {
+            // Might need to eagerly bind functions so we have the datatypes
+            return (fun.Name, default, null); // function is bound to is position
+        }
+        if (exp is BinaryExpression b)
+        {
+            // probably want the literal text of the expression here to name the column
+            return (b.Alias, b.BoundOutputColumn, b.BoundDataType); // function is bound to is position
+        }
+        throw new QueryPlanException($"Unsupported expression type '{exp.GetType().Name}'");
+    }
+
+}

--- a/src/Database.Core/Planner/ExpressionBinder.cs
+++ b/src/Database.Core/Planner/ExpressionBinder.cs
@@ -76,11 +76,6 @@ public class ExpressionBinder(ParquetPool bufferPool, FunctionRegistry functions
         IReadOnlyList<ColumnSchema> columns
         )
     {
-        if (expression.BoundFunction != null)
-        {
-            return expression.BoundFunction;
-        }
-
         if (expression is IntegerLiteral numInt)
         {
             return new LiteralFunction(numInt.Literal, DataType.Int);
@@ -118,8 +113,8 @@ public class ExpressionBinder(ParquetPool bufferPool, FunctionRegistry functions
 
         if (expression is ColumnExpression column)
         {
-            var (_, index, colType) = FindColumnIndex(columns, column);
-            return new SelectFunction(index, colType!.Value, bufferPool);
+            var (_, columnRef, colType) = FindColumnIndex(columns, column);
+            return new SelectFunction(columnRef, colType!.Value, bufferPool);
         }
 
         if (expression is BinaryExpression be)
@@ -172,11 +167,6 @@ public class ExpressionBinder(ParquetPool bufferPool, FunctionRegistry functions
 
     private static (string, ColumnRef, DataType?) FindColumnIndex(IReadOnlyList<ColumnSchema> columns, BaseExpression exp)
     {
-        if (exp.BoundOutputColumn != default)
-        {
-            return (exp.Alias, exp.BoundOutputColumn, exp.BoundDataType);
-        }
-
         // TODO we need to actually handle * and alias
         if (exp is ColumnExpression column)
         {

--- a/src/Database.Core/Planner/ExpressionBinder.cs
+++ b/src/Database.Core/Planner/ExpressionBinder.cs
@@ -34,9 +34,17 @@ public class ExpressionBinder(ParquetPool bufferPool, FunctionRegistry functions
     {
         var fun = FunctionForExpression(expression, columns, ignoreMissingColumns);
         var alias = expression.Alias;
-        if (expression is BinaryExpression b && alias == "")
+        // TODO literal of the expression (embed the lexme in it?)
+        if (alias == "")
         {
-            alias = b.Operator.ToString(); // TODO literal of the expression
+            if (expression is BinaryExpression b)
+            {
+                alias = b.Operator.ToString();
+            }
+            if (expression is FunctionExpression f)
+            {
+                alias = f.Name;
+            }
         }
 
         expression = expression with

--- a/src/Database.Core/Statements/GroupByStatement.cs
+++ b/src/Database.Core/Statements/GroupByStatement.cs
@@ -2,7 +2,7 @@ using Database.Core.Expressions;
 
 namespace Database.Core;
 
-public record GroupByStatement(List<IExpression> Expressions) : IStatement
+public record GroupByStatement(List<BaseExpression> Expressions) : IStatement
 {
 
 }

--- a/src/Database.Core/Statements/SelectListStatement.cs
+++ b/src/Database.Core/Statements/SelectListStatement.cs
@@ -2,6 +2,6 @@ using Database.Core.Expressions;
 
 namespace Database.Core;
 
-public record SelectListStatement(bool Distinct, List<IExpression> Expressions) : IStatement
+public record SelectListStatement(bool Distinct, IReadOnlyList<BaseExpression> Expressions) : IStatement
 {
 }

--- a/src/Database.Core/Statements/SelectStatement.cs
+++ b/src/Database.Core/Statements/SelectStatement.cs
@@ -2,9 +2,9 @@ using Database.Core.Expressions;
 
 namespace Database.Core;
 
-internal record SelectStatement(
+public record SelectStatement(
     SelectListStatement SelectList,
     FromStatement From,
-    IExpression? Where,
+    BaseExpression? Where,
     GroupByStatement? Group,
     OrderByStatement? Order) : IStatement;

--- a/src/Database.Test/ExecutionTest.cs
+++ b/src/Database.Test/ExecutionTest.cs
@@ -74,6 +74,29 @@ public class ExecutionTest
         values.Should().BeEquivalentTo(new List<int> { 0, 1, 2, 3, 4 });
     }
 
+    [TestCase("Id * Id")]
+    [TestCase("Id")]
+    [TestCase("Id + 1")]
+    [TestCase("Id * 2")]
+    [TestCase("Id % 2")]
+    [TestCase("Id / 1")]
+    [TestCase("Id / 2")]
+    [TestCase("Id / 8")]
+    [TestCase("Id + 1 + 1")]
+    [TestCase("Id + 1 * 3")]
+    [TestCase("0 + 1 * 3")]
+    [TestCase("0 + 1 * 6 / 2")]
+    [TestCase("0 as foo")]
+    [TestCase("0 + 1 as foo")]
+    // [TestCase("Id / 8.0")] // This doesn't work yet because we don't have upcasts
+    public void Select_Expressions(string expr)
+    {
+        var result = Query($"SELECT {expr} FROM table").AsRowList();
+
+        var res = (double)Convert.ChangeType(result[0].Values[0], typeof(double))!;
+        res.Should().BeGreaterThanOrEqualTo(0);
+    }
+
     [TestCase("Id * Id", ExpectedResult = 100)]
     [TestCase("Id", ExpectedResult = 10)]
     [TestCase("Id + 1", ExpectedResult = 11)]
@@ -89,7 +112,7 @@ public class ExecutionTest
     [TestCase("0 as foo", ExpectedResult = 0)]
     [TestCase("0 + 1 as foo", ExpectedResult = 1)]
     // [TestCase("Id / 8.0", ExpectedResult = 1.25)] // This doesn't work yet because we don't have upcasts
-    public object Select_Expressions(string expr)
+    public object Select_Expressions_With_Filter(string expr)
     {
         var result = Query($"SELECT {expr} FROM table where Id = 10;").AsRowList();
 

--- a/src/Database.Test/ExecutionTest.cs
+++ b/src/Database.Test/ExecutionTest.cs
@@ -18,15 +18,15 @@ public class ExecutionTest
         TestDatasets.AddTestDatasetsToCatalog(_catalog);
     }
 
-    private List<RowGroup> Query(string query)
+    private List<MaterializedRowGroup> Query(string query)
     {
         var scanner = new Scanner(query);
         var tokens = scanner.ScanTokens();
         var parser = new Parser(tokens);
         var statement = parser.Parse();
 
-        var it = new Interpreter();
         var bufferPool = new ParquetPool();
+        var it = new Interpreter(bufferPool);
         var planner = new QueryPlanner(_catalog, bufferPool);
         var plan = planner.CreatePlan(statement);
         var result = it.Execute(plan).ToList();

--- a/src/Database.Test/ParquetPoolTests.cs
+++ b/src/Database.Test/ParquetPoolTests.cs
@@ -17,10 +17,10 @@ public class ParquetPoolTests
         table.AddColumnToSchema("bar", DataType.String);
 
         var colRef1 = new ColumnRef(memRef, 0, 0);
-        table.PutColumn(colRef1, ColumnHelper.CreateColumn(typeof(int), "foo", 0, new int[] { 1, 2, 3 }));
+        table.PutColumn(colRef1, ColumnHelper.CreateColumn(typeof(int), "foo", new int[] { 1, 2, 3 }));
 
         var colRef2 = new ColumnRef(memRef, 0, 1);
-        table.PutColumn(colRef2, ColumnHelper.CreateColumn(typeof(string), "bar", 1, new string[] { "one", "two", "three" }));
+        table.PutColumn(colRef2, ColumnHelper.CreateColumn(typeof(string), "bar", new string[] { "one", "two", "three" }));
 
         var column = table.GetColumn(colRef1);
         column.Name.Should().Be("foo");

--- a/src/Database.Test/ParquetPoolTests.cs
+++ b/src/Database.Test/ParquetPoolTests.cs
@@ -1,0 +1,30 @@
+using Database.Core.BufferPool;
+using Database.Core.Execution;
+using FluentAssertions;
+
+namespace Database.Test;
+
+public class ParquetPoolTests
+{
+    [Test]
+    public void WriteToMemoryTable()
+    {
+        var pool = new ParquetPool();
+        var memRef = pool.OpenMemoryTable(2);
+        var table = pool.GetMemoryTable(memRef.TableId);
+
+        var colRef1 = new ColumnRef(memRef, 0, 0);
+        table.PutColumn(colRef1, ColumnHelper.CreateColumn(typeof(int), "foo", 0, new int[] { 1, 2, 3 }));
+
+        var colRef2 = new ColumnRef(memRef, 0, 1);
+        table.PutColumn(colRef2, ColumnHelper.CreateColumn(typeof(string), "bar", 1, new string[] { "one", "two", "three" }));
+
+        var column = table.GetColumn(colRef1);
+        column.Name.Should().Be("foo");
+        column.ValuesArray.Should().BeEquivalentTo(new int[] { 1, 2, 3 });
+
+        var column2 = table.GetColumn(colRef2);
+        column2.Name.Should().Be("bar");
+        column2.ValuesArray.Should().BeEquivalentTo(new string[] { "one", "two", "three" });
+    }
+}

--- a/src/Database.Test/ParquetPoolTests.cs
+++ b/src/Database.Test/ParquetPoolTests.cs
@@ -1,4 +1,5 @@
 using Database.Core.BufferPool;
+using Database.Core.Catalog;
 using Database.Core.Execution;
 using FluentAssertions;
 
@@ -10,8 +11,10 @@ public class ParquetPoolTests
     public void WriteToMemoryTable()
     {
         var pool = new ParquetPool();
-        var memRef = pool.OpenMemoryTable(2);
+        var memRef = pool.OpenMemoryTable();
         var table = pool.GetMemoryTable(memRef.TableId);
+        table.AddColumnToSchema("foo", DataType.Int);
+        table.AddColumnToSchema("bar", DataType.String);
 
         var colRef1 = new ColumnRef(memRef, 0, 0);
         table.PutColumn(colRef1, ColumnHelper.CreateColumn(typeof(int), "foo", 0, new int[] { 1, 2, 3 }));

--- a/src/Database.Test/Snapshots/Parser/ParserTest.Aggregations_expression=count(1).verified.txt
+++ b/src/Database.Test/Snapshots/Parser/ParserTest.Aggregations_expression=count(1).verified.txt
@@ -7,11 +7,9 @@
         Args: [
           {
             Literal: 1,
-            BoundIndex: -1,
             Alias: 
           }
         ],
-        BoundIndex: -1,
         Alias: 
       }
     ]

--- a/src/Database.Test/Snapshots/Parser/ParserTest.Aggregations_expression=count(a).verified.txt
+++ b/src/Database.Test/Snapshots/Parser/ParserTest.Aggregations_expression=count(a).verified.txt
@@ -7,11 +7,9 @@
         Args: [
           {
             Column: a,
-            BoundIndex: -1,
             Alias: a
           }
         ],
-        BoundIndex: -1,
         Alias: 
       }
     ]

--- a/src/Database.Test/Snapshots/Parser/ParserTest.Aggregations_expression=sum(1).verified.txt
+++ b/src/Database.Test/Snapshots/Parser/ParserTest.Aggregations_expression=sum(1).verified.txt
@@ -7,11 +7,9 @@
         Args: [
           {
             Literal: 1,
-            BoundIndex: -1,
             Alias: 
           }
         ],
-        BoundIndex: -1,
         Alias: 
       }
     ]

--- a/src/Database.Test/Snapshots/Parser/ParserTest.Aggregations_expression=sum(a + b - 1).verified.txt
+++ b/src/Database.Test/Snapshots/Parser/ParserTest.Aggregations_expression=sum(a + b - 1).verified.txt
@@ -9,29 +9,23 @@
             Operator: PLUS,
             Left: {
               Column: a,
-              BoundIndex: -1,
               Alias: a
             },
             Right: {
               Operator: STAR,
               Left: {
                 Column: b,
-                BoundIndex: -1,
                 Alias: b
               },
               Right: {
                 Literal: 1,
-                BoundIndex: -1,
                 Alias: 
               },
-              BoundIndex: -1,
               Alias: 
             },
-            BoundIndex: -1,
             Alias: 
           }
         ],
-        BoundIndex: -1,
         Alias: 
       }
     ]

--- a/src/Database.Test/Snapshots/Parser/ParserTest.Aggregations_expression=sum(a + b).verified.txt
+++ b/src/Database.Test/Snapshots/Parser/ParserTest.Aggregations_expression=sum(a + b).verified.txt
@@ -9,19 +9,15 @@
             Operator: PLUS,
             Left: {
               Column: a,
-              BoundIndex: -1,
               Alias: a
             },
             Right: {
               Column: b,
-              BoundIndex: -1,
               Alias: b
             },
-            BoundIndex: -1,
             Alias: 
           }
         ],
-        BoundIndex: -1,
         Alias: 
       }
     ]

--- a/src/Database.Test/Snapshots/Parser/ParserTest.Aggregations_expression=sum(a), count(a).verified.txt
+++ b/src/Database.Test/Snapshots/Parser/ParserTest.Aggregations_expression=sum(a), count(a).verified.txt
@@ -7,11 +7,9 @@
         Args: [
           {
             Column: a,
-            BoundIndex: -1,
             Alias: a
           }
         ],
-        BoundIndex: -1,
         Alias: 
       },
       {
@@ -19,11 +17,9 @@
         Args: [
           {
             Column: a,
-            BoundIndex: -1,
             Alias: a
           }
         ],
-        BoundIndex: -1,
         Alias: 
       }
     ]

--- a/src/Database.Test/Snapshots/Parser/ParserTest.Aggregations_expression=sum(a).verified.txt
+++ b/src/Database.Test/Snapshots/Parser/ParserTest.Aggregations_expression=sum(a).verified.txt
@@ -7,11 +7,9 @@
         Args: [
           {
             Column: a,
-            BoundIndex: -1,
             Alias: a
           }
         ],
-        BoundIndex: -1,
         Alias: 
       }
     ]

--- a/src/Database.Test/Snapshots/Parser/ParserTest.Aggregations_expression=sum(b - 1 + a).verified.txt
+++ b/src/Database.Test/Snapshots/Parser/ParserTest.Aggregations_expression=sum(b - 1 + a).verified.txt
@@ -11,27 +11,21 @@
               Operator: STAR,
               Left: {
                 Column: b,
-                BoundIndex: -1,
                 Alias: b
               },
               Right: {
                 Literal: 1,
-                BoundIndex: -1,
                 Alias: 
               },
-              BoundIndex: -1,
               Alias: 
             },
             Right: {
               Column: a,
-              BoundIndex: -1,
               Alias: a
             },
-            BoundIndex: -1,
             Alias: 
           }
         ],
-        BoundIndex: -1,
         Alias: 
       }
     ]

--- a/src/Database.Test/Snapshots/Parser/ParserTest.ScalarMath_expr=200 % 1.verified.txt
+++ b/src/Database.Test/Snapshots/Parser/ParserTest.ScalarMath_expr=200 % 1.verified.txt
@@ -6,15 +6,12 @@
         Operator: PERCENT,
         Left: {
           Literal: 200,
-          BoundIndex: -1,
           Alias: 
         },
         Right: {
           Literal: 1,
-          BoundIndex: -1,
           Alias: 
         },
-        BoundIndex: -1,
         Alias: 
       }
     ]

--- a/src/Database.Test/Snapshots/Parser/ParserTest.ScalarMath_expr=200 % Id.verified.txt
+++ b/src/Database.Test/Snapshots/Parser/ParserTest.ScalarMath_expr=200 % Id.verified.txt
@@ -6,15 +6,12 @@
         Operator: PERCENT,
         Left: {
           Literal: 200,
-          BoundIndex: -1,
           Alias: 
         },
         Right: {
           Column: Id,
-          BoundIndex: -1,
           Alias: Id
         },
-        BoundIndex: -1,
         Alias: 
       }
     ]

--- a/src/Database.Test/Snapshots/Parser/ParserTest.ScalarMath_expr=200 + 1.verified.txt
+++ b/src/Database.Test/Snapshots/Parser/ParserTest.ScalarMath_expr=200 + 1.verified.txt
@@ -6,15 +6,12 @@
         Operator: PLUS,
         Left: {
           Literal: 200,
-          BoundIndex: -1,
           Alias: 
         },
         Right: {
           Literal: 1,
-          BoundIndex: -1,
           Alias: 
         },
-        BoundIndex: -1,
         Alias: 
       }
     ]

--- a/src/Database.Test/Snapshots/Parser/ParserTest.ScalarMath_expr=200 + Id.verified.txt
+++ b/src/Database.Test/Snapshots/Parser/ParserTest.ScalarMath_expr=200 + Id.verified.txt
@@ -6,15 +6,12 @@
         Operator: PLUS,
         Left: {
           Literal: 200,
-          BoundIndex: -1,
           Alias: 
         },
         Right: {
           Column: Id,
-          BoundIndex: -1,
           Alias: Id
         },
-        BoundIndex: -1,
         Alias: 
       }
     ]

--- a/src/Database.Test/Snapshots/Parser/ParserTest.ScalarMath_expr=200 - 1.verified.txt
+++ b/src/Database.Test/Snapshots/Parser/ParserTest.ScalarMath_expr=200 - 1.verified.txt
@@ -6,15 +6,12 @@
         Operator: MINUS,
         Left: {
           Literal: 200,
-          BoundIndex: -1,
           Alias: 
         },
         Right: {
           Literal: 1,
-          BoundIndex: -1,
           Alias: 
         },
-        BoundIndex: -1,
         Alias: 
       }
     ]

--- a/src/Database.Test/Snapshots/Parser/ParserTest.ScalarMath_expr=200 - Id.verified.txt
+++ b/src/Database.Test/Snapshots/Parser/ParserTest.ScalarMath_expr=200 - Id.verified.txt
@@ -6,15 +6,12 @@
         Operator: MINUS,
         Left: {
           Literal: 200,
-          BoundIndex: -1,
           Alias: 
         },
         Right: {
           Column: Id,
-          BoundIndex: -1,
           Alias: Id
         },
-        BoundIndex: -1,
         Alias: 
       }
     ]

--- a/src/Database.Test/Snapshots/Parser/ParserTest.ScalarMath_expr=200 SLASH 1.verified.txt
+++ b/src/Database.Test/Snapshots/Parser/ParserTest.ScalarMath_expr=200 SLASH 1.verified.txt
@@ -6,15 +6,12 @@
         Operator: SLASH,
         Left: {
           Literal: 200,
-          BoundIndex: -1,
           Alias: 
         },
         Right: {
           Literal: 1,
-          BoundIndex: -1,
           Alias: 
         },
-        BoundIndex: -1,
         Alias: 
       }
     ]

--- a/src/Database.Test/Snapshots/Parser/ParserTest.ScalarMath_expr=200 SLASH Id.verified.txt
+++ b/src/Database.Test/Snapshots/Parser/ParserTest.ScalarMath_expr=200 SLASH Id.verified.txt
@@ -6,15 +6,12 @@
         Operator: SLASH,
         Left: {
           Literal: 200,
-          BoundIndex: -1,
           Alias: 
         },
         Right: {
           Column: Id,
-          BoundIndex: -1,
           Alias: Id
         },
-        BoundIndex: -1,
         Alias: 
       }
     ]

--- a/src/Database.Test/Snapshots/Parser/ParserTest.ScalarMath_expr=200 STAR 1.verified.txt
+++ b/src/Database.Test/Snapshots/Parser/ParserTest.ScalarMath_expr=200 STAR 1.verified.txt
@@ -6,15 +6,12 @@
         Operator: STAR,
         Left: {
           Literal: 200,
-          BoundIndex: -1,
           Alias: 
         },
         Right: {
           Literal: 1,
-          BoundIndex: -1,
           Alias: 
         },
-        BoundIndex: -1,
         Alias: 
       }
     ]

--- a/src/Database.Test/Snapshots/Parser/ParserTest.ScalarMath_expr=200 STAR Id.verified.txt
+++ b/src/Database.Test/Snapshots/Parser/ParserTest.ScalarMath_expr=200 STAR Id.verified.txt
@@ -6,15 +6,12 @@
         Operator: STAR,
         Left: {
           Literal: 200,
-          BoundIndex: -1,
           Alias: 
         },
         Right: {
           Column: Id,
-          BoundIndex: -1,
           Alias: Id
         },
-        BoundIndex: -1,
         Alias: 
       }
     ]

--- a/src/Database.Test/Snapshots/Parser/ParserTest.ScalarMath_expr=Id % 100.verified.txt
+++ b/src/Database.Test/Snapshots/Parser/ParserTest.ScalarMath_expr=Id % 100.verified.txt
@@ -6,15 +6,12 @@
         Operator: PERCENT,
         Left: {
           Column: Id,
-          BoundIndex: -1,
           Alias: Id
         },
         Right: {
           Literal: 100,
-          BoundIndex: -1,
           Alias: 
         },
-        BoundIndex: -1,
         Alias: 
       }
     ]

--- a/src/Database.Test/Snapshots/Parser/ParserTest.ScalarMath_expr=Id + 100.verified.txt
+++ b/src/Database.Test/Snapshots/Parser/ParserTest.ScalarMath_expr=Id + 100.verified.txt
@@ -6,15 +6,12 @@
         Operator: PLUS,
         Left: {
           Column: Id,
-          BoundIndex: -1,
           Alias: Id
         },
         Right: {
           Literal: 100,
-          BoundIndex: -1,
           Alias: 
         },
-        BoundIndex: -1,
         Alias: 
       }
     ]

--- a/src/Database.Test/Snapshots/Parser/ParserTest.ScalarMath_expr=Id - 100.verified.txt
+++ b/src/Database.Test/Snapshots/Parser/ParserTest.ScalarMath_expr=Id - 100.verified.txt
@@ -6,15 +6,12 @@
         Operator: MINUS,
         Left: {
           Column: Id,
-          BoundIndex: -1,
           Alias: Id
         },
         Right: {
           Literal: 100,
-          BoundIndex: -1,
           Alias: 
         },
-        BoundIndex: -1,
         Alias: 
       }
     ]

--- a/src/Database.Test/Snapshots/Parser/ParserTest.ScalarMath_expr=Id SLASH 100.verified.txt
+++ b/src/Database.Test/Snapshots/Parser/ParserTest.ScalarMath_expr=Id SLASH 100.verified.txt
@@ -6,15 +6,12 @@
         Operator: SLASH,
         Left: {
           Column: Id,
-          BoundIndex: -1,
           Alias: Id
         },
         Right: {
           Literal: 100,
-          BoundIndex: -1,
           Alias: 
         },
-        BoundIndex: -1,
         Alias: 
       }
     ]

--- a/src/Database.Test/Snapshots/Parser/ParserTest.ScalarMath_expr=Id STAR 100.verified.txt
+++ b/src/Database.Test/Snapshots/Parser/ParserTest.ScalarMath_expr=Id STAR 100.verified.txt
@@ -6,15 +6,12 @@
         Operator: STAR,
         Left: {
           Column: Id,
-          BoundIndex: -1,
           Alias: Id
         },
         Right: {
           Literal: 100,
-          BoundIndex: -1,
           Alias: 
         },
-        BoundIndex: -1,
         Alias: 
       }
     ]

--- a/src/Database.Test/Snapshots/Parser/ParserTest.Test_expression=-.verified.txt
+++ b/src/Database.Test/Snapshots/Parser/ParserTest.Test_expression=-.verified.txt
@@ -3,7 +3,6 @@
     Distinct: false,
     Expressions: [
       {
-        BoundIndex: -1,
         Alias: 
       }
     ]

--- a/src/Database.Test/Snapshots/Parser/ParserTest.Test_expression=a, b, t.a, t.b, t.-, -.verified.txt
+++ b/src/Database.Test/Snapshots/Parser/ParserTest.Test_expression=a, b, t.a, t.b, t.-, -.verified.txt
@@ -4,33 +4,27 @@
     Expressions: [
       {
         Column: a,
-        BoundIndex: -1,
         Alias: a
       },
       {
         Column: b,
-        BoundIndex: -1,
         Alias: b
       },
       {
         Column: a,
         Table: t,
-        BoundIndex: -1,
         Alias: a
       },
       {
         Column: b,
         Table: t,
-        BoundIndex: -1,
         Alias: b
       },
       {
         Table: t,
-        BoundIndex: -1,
         Alias: 
       },
       {
-        BoundIndex: -1,
         Alias: 
       }
     ]

--- a/src/Database.Test/Snapshots/Parser/ParserTest.Test_expression=a, b.verified.txt
+++ b/src/Database.Test/Snapshots/Parser/ParserTest.Test_expression=a, b.verified.txt
@@ -4,12 +4,10 @@
     Expressions: [
       {
         Column: a,
-        BoundIndex: -1,
         Alias: a
       },
       {
         Column: b,
-        BoundIndex: -1,
         Alias: b
       }
     ]

--- a/src/Database.Test/Snapshots/Parser/ParserTest.Test_expression=a.verified.txt
+++ b/src/Database.Test/Snapshots/Parser/ParserTest.Test_expression=a.verified.txt
@@ -4,7 +4,6 @@
     Expressions: [
       {
         Column: a,
-        BoundIndex: -1,
         Alias: a
       }
     ]

--- a/src/Database.Test/Snapshots/Parser/ParserTest.Test_expression=all a, b.verified.txt
+++ b/src/Database.Test/Snapshots/Parser/ParserTest.Test_expression=all a, b.verified.txt
@@ -4,12 +4,10 @@
     Expressions: [
       {
         Column: a,
-        BoundIndex: -1,
         Alias: a
       },
       {
         Column: b,
-        BoundIndex: -1,
         Alias: b
       }
     ]

--- a/src/Database.Test/Snapshots/Parser/ParserTest.Test_expression=distinct a, b.verified.txt
+++ b/src/Database.Test/Snapshots/Parser/ParserTest.Test_expression=distinct a, b.verified.txt
@@ -4,12 +4,10 @@
     Expressions: [
       {
         Column: a,
-        BoundIndex: -1,
         Alias: a
       },
       {
         Column: b,
-        BoundIndex: -1,
         Alias: b
       }
     ]

--- a/src/Database.Test/Snapshots/Parser/ParserTest.Test_expression=t.-.verified.txt
+++ b/src/Database.Test/Snapshots/Parser/ParserTest.Test_expression=t.-.verified.txt
@@ -4,7 +4,6 @@
     Expressions: [
       {
         Table: t,
-        BoundIndex: -1,
         Alias: 
       }
     ]

--- a/src/Database.Test/Snapshots/Parser/ParserTest.Test_expression=t.a, t.b.verified.txt
+++ b/src/Database.Test/Snapshots/Parser/ParserTest.Test_expression=t.a, t.b.verified.txt
@@ -5,13 +5,11 @@
       {
         Column: a,
         Table: t,
-        BoundIndex: -1,
         Alias: a
       },
       {
         Column: b,
         Table: t,
-        BoundIndex: -1,
         Alias: b
       }
     ]

--- a/src/Database.Test/Snapshots/Parser/ParserTest.Test_expression=t.a.verified.txt
+++ b/src/Database.Test/Snapshots/Parser/ParserTest.Test_expression=t.a.verified.txt
@@ -5,7 +5,6 @@
       {
         Column: a,
         Table: t,
-        BoundIndex: -1,
         Alias: a
       }
     ]

--- a/src/Database.Test/Snapshots/Parser/ParserTest.Where_expr=100 != Id.verified.txt
+++ b/src/Database.Test/Snapshots/Parser/ParserTest.Where_expr=100 != Id.verified.txt
@@ -4,7 +4,6 @@
     Expressions: [
       {
         Column: Id,
-        BoundIndex: -1,
         Alias: Id
       }
     ]
@@ -17,15 +16,12 @@
     Operator: BANG_EQUAL,
     Left: {
       Literal: 100,
-      BoundIndex: -1,
       Alias: 
     },
     Right: {
       Column: Id,
-      BoundIndex: -1,
       Alias: Id
     },
-    BoundIndex: -1,
     Alias: 
   }
 }

--- a/src/Database.Test/Snapshots/Parser/ParserTest.Where_expr=100 = Id.verified.txt
+++ b/src/Database.Test/Snapshots/Parser/ParserTest.Where_expr=100 = Id.verified.txt
@@ -4,7 +4,6 @@
     Expressions: [
       {
         Column: Id,
-        BoundIndex: -1,
         Alias: Id
       }
     ]
@@ -17,15 +16,12 @@
     Operator: EQUAL,
     Left: {
       Literal: 100,
-      BoundIndex: -1,
       Alias: 
     },
     Right: {
       Column: Id,
-      BoundIndex: -1,
       Alias: Id
     },
-    BoundIndex: -1,
     Alias: 
   }
 }

--- a/src/Database.Test/Snapshots/Parser/ParserTest.Where_expr=100 GREATER Id.verified.txt
+++ b/src/Database.Test/Snapshots/Parser/ParserTest.Where_expr=100 GREATER Id.verified.txt
@@ -4,7 +4,6 @@
     Expressions: [
       {
         Column: Id,
-        BoundIndex: -1,
         Alias: Id
       }
     ]
@@ -17,15 +16,12 @@
     Operator: GREATER,
     Left: {
       Literal: 100,
-      BoundIndex: -1,
       Alias: 
     },
     Right: {
       Column: Id,
-      BoundIndex: -1,
       Alias: Id
     },
-    BoundIndex: -1,
     Alias: 
   }
 }

--- a/src/Database.Test/Snapshots/Parser/ParserTest.Where_expr=100 GREATER= Id.verified.txt
+++ b/src/Database.Test/Snapshots/Parser/ParserTest.Where_expr=100 GREATER= Id.verified.txt
@@ -4,7 +4,6 @@
     Expressions: [
       {
         Column: Id,
-        BoundIndex: -1,
         Alias: Id
       }
     ]
@@ -17,15 +16,12 @@
     Operator: GREATER_EQUAL,
     Left: {
       Literal: 100,
-      BoundIndex: -1,
       Alias: 
     },
     Right: {
       Column: Id,
-      BoundIndex: -1,
       Alias: Id
     },
-    BoundIndex: -1,
     Alias: 
   }
 }

--- a/src/Database.Test/Snapshots/Parser/ParserTest.Where_expr=Id LESS 100.verified.txt
+++ b/src/Database.Test/Snapshots/Parser/ParserTest.Where_expr=Id LESS 100.verified.txt
@@ -4,7 +4,6 @@
     Expressions: [
       {
         Column: Id,
-        BoundIndex: -1,
         Alias: Id
       }
     ]
@@ -17,15 +16,12 @@
     Operator: LESS,
     Left: {
       Column: Id,
-      BoundIndex: -1,
       Alias: Id
     },
     Right: {
       Literal: 100,
-      BoundIndex: -1,
       Alias: 
     },
-    BoundIndex: -1,
     Alias: 
   }
 }

--- a/src/Database.Test/Snapshots/Parser/ParserTest.Where_expr=Id LESS= 100.verified.txt
+++ b/src/Database.Test/Snapshots/Parser/ParserTest.Where_expr=Id LESS= 100.verified.txt
@@ -4,7 +4,6 @@
     Expressions: [
       {
         Column: Id,
-        BoundIndex: -1,
         Alias: Id
       }
     ]
@@ -17,15 +16,12 @@
     Operator: LESS_EQUAL,
     Left: {
       Column: Id,
-      BoundIndex: -1,
       Alias: Id
     },
     Right: {
       Literal: 100,
-      BoundIndex: -1,
       Alias: 
     },
-    BoundIndex: -1,
     Alias: 
   }
 }


### PR DESCRIPTION
Push data into the buffer pool and return references to column groups rather than sending the data back directly to the calling operator. The AST was also refactored to be immutable, allowing for easier re-writing and re-binding of the query between different operations. Together, these allowed for projection push down (pushing the select statements) into the scan operator, removing unnecessary time spent decoding columns that are never used by the query. 

This is about a ~35% speedup on Q1. The flamegraph is now dominated by the hashaggregate, so that's the next obvious target for optimization. 



<img width="1925" height="800" alt="image" src="https://github.com/user-attachments/assets/ee84f2d4-0176-4db4-b5fe-bf78ad48ee3b" />

